### PR TITLE
Take 3D shape into account in examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ const pixels = await getPixels(bytesIn, 'image/png'); // Uint8Array -> ndarray
 // modify
 for (let i = 0; i < pixels.shape[0]; ++i) {
   for (let j = 0; j < pixels.shape[1]; ++j) {
-    pixels.set(i, j, 255);
+    for (let k = 0; k < pixels.shape[2]; ++k) {
+      pixels.set(i, j, k, 255);
+    }
   }
 }
 
@@ -64,7 +66,9 @@ const pixels = await getPixels(bufferIn, 'image/png'); // Uint8Array -> ndarray
 // modify
 for (let i = 0; i < pixels.shape[0]; ++i) {
   for (let j = 0; j < pixels.shape[1]; ++j) {
-    pixels.set(i, j, 255);
+    for (let k = 0; k < pixels.shape[2]; ++k) {
+      pixels.set(i, j, k, 255);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/donmccurdy/ndarray-pixels/issues/155

The examples in the `README.md` iterated only over 2 of the 3 shape dimensions, causing a currupted image to be generated.

This is the _minimal_ fix.

I'd lean towards describing in more detail what's happening there, either in the TSDoc of the functions themself or as inlined comments in the example, like
```
// shape[0] is the width of the image
// shape[1] is the height of the image
// shape[2] is always 4, for the RGBA channels of the pixels
```
But I didn't want to mess around _beyond_ the main fix. Just drop me a note if further comments should be added.
