### PR TITLE
Use OffscreenCanvas

### DIFF
--- a/src/browser-get-pixels.ts
+++ b/src/browser-get-pixels.ts
@@ -20,9 +20,7 @@ export function getPixelsInternal(
 		img.onload = function () {
 			URL.revokeObjectURL(path as string);
 
-			const canvas = document.createElement('canvas');
-			canvas.width = img.width;
-			canvas.height = img.height;
+			const canvas = new OffscreenCanvas(img.width, img.height)
 			const context = canvas.getContext('2d')!;
 			context.drawImage(img, 0, 0);
 			const pixels = context.getImageData(0, 0, img.width, img.height);


### PR DESCRIPTION
Now that OffscreenCanvas is widely available, use it. This makes the package no longer rely on `document` and usable in worker threads.