### PR TITLE
Use createImageBitmap to decode image if available

### DIFF
--- a/src/browser-get-pixels.ts
+++ b/src/browser-get-pixels.ts
@@ -1,6 +1,35 @@
 import ndarray from 'ndarray';
 import type { NdArray } from 'ndarray';
 
+function decodeImage(blob: Blob): Promise<HTMLImageElement | ImageBitmap> {
+	// Decode image with createImageBitmap API.
+	if (typeof createImageBitmap === 'function') {
+		return createImageBitmap(blob, {
+			premultiplyAlpha: 'none',
+		});
+	}
+	if (typeof Image !== 'function') {
+		throw new Error('[ndarray-pixels] Can not decode image.');
+	}
+	const path = URL.createObjectURL(blob);
+	
+	// Decode image with Image constructor API.
+	return new Promise((resolve, reject) => {
+		const img = new Image();
+		img.crossOrigin = 'anonymous';
+		img.onload = function () {
+			URL.revokeObjectURL(path as string);
+
+			resolve(img);
+		};
+		img.onerror = (err) => {
+			URL.revokeObjectURL(path as string);
+			reject(err);
+		};
+		img.src = path;
+	});
+}
+
 export function getPixelsInternal(
 	buffer: Uint8Array,
 	mimeType: string
@@ -11,32 +40,16 @@ export function getPixelsInternal(
 	}
 
 	const blob = new Blob([buffer], { type: mimeType });
-	const path = URL.createObjectURL(blob);
-
-	// Decode image with Canvas API.
-	return new Promise((resolve, reject) => {
-		const img = new Image();
-		img.crossOrigin = 'anonymous';
-		img.onload = function () {
-			URL.revokeObjectURL(path as string);
-
-			const canvas = new OffscreenCanvas(img.width, img.height);
-			const context = canvas.getContext('2d')!;
-			context.drawImage(img, 0, 0);
-			const pixels = context.getImageData(0, 0, img.width, img.height);
-			resolve(
-				ndarray(
-					new Uint8Array(pixels.data),
-					[img.width, img.height, 4],
-					[4, 4 * img.width, 1],
-					0
-				)
-			);
-		};
-		img.onerror = (err) => {
-			URL.revokeObjectURL(path as string);
-			reject(err);
-		};
-		img.src = path;
+	return decodeImage(blob).then(img => {
+		const canvas = new OffscreenCanvas(img.width, img.height);
+		const context = canvas.getContext('2d')!;
+		context.drawImage(img, 0, 0);
+		const pixels = context.getImageData(0, 0, img.width, img.height);
+		return ndarray(
+			new Uint8Array(pixels.data),
+			[img.width, img.height, 4],
+			[4, 4 * img.width, 1],
+			0
+		);
 	});
 }

--- a/src/browser-get-pixels.ts
+++ b/src/browser-get-pixels.ts
@@ -1,35 +1,6 @@
 import ndarray from 'ndarray';
 import type { NdArray } from 'ndarray';
 
-function decodeImage(blob: Blob): Promise<HTMLImageElement | ImageBitmap> {
-	// Decode image with createImageBitmap API.
-	if (typeof createImageBitmap === 'function') {
-		return createImageBitmap(blob, {
-			premultiplyAlpha: 'none',
-		});
-	}
-	if (typeof Image !== 'function') {
-		throw new Error('[ndarray-pixels] Can not decode image.');
-	}
-	const path = URL.createObjectURL(blob);
-	
-	// Decode image with Image constructor API.
-	return new Promise((resolve, reject) => {
-		const img = new Image();
-		img.crossOrigin = 'anonymous';
-		img.onload = function () {
-			URL.revokeObjectURL(path as string);
-
-			resolve(img);
-		};
-		img.onerror = (err) => {
-			URL.revokeObjectURL(path as string);
-			reject(err);
-		};
-		img.src = path;
-	});
-}
-
 export function getPixelsInternal(
 	buffer: Uint8Array,
 	mimeType: string
@@ -40,7 +11,10 @@ export function getPixelsInternal(
 	}
 
 	const blob = new Blob([buffer], { type: mimeType });
-	return decodeImage(blob).then(img => {
+	return createImageBitmap(blob, {
+		premultiplyAlpha: 'none',
+		colorSpaceConversion: 'none',
+	}).then(img => {
 		const canvas = new OffscreenCanvas(img.width, img.height);
 		const context = canvas.getContext('2d')!;
 		context.drawImage(img, 0, 0);


### PR DESCRIPTION
This commit can allow usage with Web Worker on browsers supporting createImageBitmap api.
Also, this is not a breaking change since Image constructor is kept for running it on browsers without createImageBitmap api. In this case, it would only run on main thread with DOM access.
This should fix #264